### PR TITLE
Fix compilation for lean version 4.2.0-rc1

### DIFF
--- a/REPL/Lean/Environment.lean
+++ b/REPL/Lean/Environment.lean
@@ -19,7 +19,7 @@ def pickle (env : Environment) (path : FilePath) : IO Unit :=
 
 unsafe def unpickleAux (path : FilePath) : IO (Environment × CompactedRegion) := do
   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
-  let env ← importModules imports.toList {} 0
+  let env ← importModules imports {} 0
   return (← env.replay (HashMap.ofList map₂.toList), region)
 
 /--

--- a/REPL/Snapshots.lean
+++ b/REPL/Snapshots.lean
@@ -80,7 +80,7 @@ unsafe def unpickleAux (path : FilePath) : IO (CommandSnapshot × CompactedRegio
   let ((imports, map₂, cmdState, cmdContext), region) ←
     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
       Command.Context) path
-  let env ← (← importModules imports.toList {} 0).replay (HashMap.ofList map₂.toList)
+  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
   let p' : CommandSnapshot :=
   { cmdState := { cmdState with env }
     cmdContext }
@@ -285,7 +285,7 @@ unsafe def unpickleAux (path : FilePath) (cmd? : Option CommandSnapshot) :
   let env ← match cmd? with
   | none =>
     enableInitializersExecution
-    (← importModules imports.toList {} 0).replay (HashMap.ofList map₂.toList)
+    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
   | some cmd =>
     cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
   let p' : ProofSnapshot :=

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-08-19
+leanprover/lean4:4.2.0-rc1


### PR DESCRIPTION
I don't actually expect this to be merged since I'm sure it will break things I don't know about, but I just wanted to submit the PR so you were aware this bug existed. 

I tried building your `backport` branch with lean version `4.2.0-rc1` and it broke complaining about this code, so I fixed it and now it compiles. Not sure if there's a fix which will work for all Lean versions, but if there is that would be great. Or if there's a way to do conditionals depending on lean version like there is in C/C++. 